### PR TITLE
Triangulate ourselves w/ earcut (fix with holes)

### DIFF
--- a/examples/multilinestring/app.tsx
+++ b/examples/multilinestring/app.tsx
@@ -24,9 +24,6 @@ const NAV_CONTROL_STYLE = {
   left: 10,
 };
 
-console.log("multipoint")
-console.log(arrow);
-
 function Root() {
   const onClick = (info) => {
     if (info.object) {

--- a/examples/multipoint/app.tsx
+++ b/examples/multipoint/app.tsx
@@ -24,9 +24,6 @@ const NAV_CONTROL_STYLE = {
   left: 10,
 };
 
-console.log("multipoint")
-console.log(arrow);
-
 function Root() {
   const onClick = (info) => {
     if (info.object) {

--- a/examples/multipolygon/app.tsx
+++ b/examples/multipolygon/app.tsx
@@ -54,9 +54,6 @@ function Root() {
       new GeoArrowSolidPolygonLayer({
         id: "geoarrow-polygons",
         data: table,
-        filled: true,
-        wireframe: true,
-        extruded: true,
         getPolygon: table.getChild("geometry")!,
         getFillColor: table.getChild("pop_colors")!,
         pickable: true,

--- a/examples/multipolygon/generate_data.py
+++ b/examples/multipolygon/generate_data.py
@@ -27,10 +27,11 @@ def main():
     min_pop = np.min(log_pop_est)
     max_pop = np.max(log_pop_est)
     normalized = (log_pop_est - min_pop) / (max_pop - min_pop)
-    colors = apply_continuous_cmap(normalized, PRGn_11)
+    colors = apply_continuous_cmap(normalized, PRGn_11, alpha=0.5)
 
     table = table.append_column(
-        "pop_colors", pa.FixedSizeListArray.from_arrays(colors.flatten("C"), 3)
+        "pop_colors",
+        pa.FixedSizeListArray.from_arrays(colors.flatten("C"), colors.shape[-1]),
     )
 
     feather.write_feather(

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@deck.gl/core": "^8.9.23",
         "@deck.gl/layers": "^8.9.23",
+        "@math.gl/polygon": "^3.6.2",
         "@rollup/plugin-terser": "^0.4.3",
         "@rollup/plugin-typescript": "^11.1.2",
         "apache-arrow": "^13.0.0",
@@ -27,6 +28,7 @@
       "peerDependencies": {
         "@deck.gl/core": "^8.9.23",
         "@deck.gl/layers": "^8.9.23",
+        "@math.gl/polygon": "^3.6.2",
         "apache-arrow": "^13.0.0"
       }
     },
@@ -70,6 +72,23 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "apache-arrow": "^13.0.0",
+        "deck.gl": "^8.9.23",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-map-gl": "^5.3.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "vite": "^4.0.0"
+      }
+    },
+    "examples/multipolygon": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@geoarrow/deck.gl-layers": "../../",
         "apache-arrow": "^13.0.0",
         "deck.gl": "^8.9.23",
         "react": "^18.0.0",
@@ -2196,6 +2215,10 @@
     },
     "node_modules/deckgl-example-geoarrow-multipoint-layer": {
       "resolved": "examples/multipoint",
+      "link": true
+    },
+    "node_modules/deckgl-example-geoarrow-multipolygon-layer": {
+      "resolved": "examples/multipolygon",
       "link": true
     },
     "node_modules/deckgl-example-geoarrow-point-layer": {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
   "peerDependencies": {
     "@deck.gl/core": "^8.9.23",
     "@deck.gl/layers": "^8.9.23",
+    "@math.gl/polygon": "^3.6.2",
     "apache-arrow": "^13.0.0"
   },
   "devDependencies": {
     "@deck.gl/core": "^8.9.23",
     "@deck.gl/layers": "^8.9.23",
+    "@math.gl/polygon": "^3.6.2",
     "@rollup/plugin-terser": "^0.4.3",
     "@rollup/plugin-typescript": "^11.1.2",
     "apache-arrow": "^13.0.0",

--- a/src/earcut.ts
+++ b/src/earcut.ts
@@ -48,6 +48,8 @@ function earcutSinglePolygon(data: PolygonData, geomIndex: number): number[] {
   for (let holeRingIdx = ringBegin + 1; holeRingIdx < ringEnd; holeRingIdx++) {
     holeIndices.push(ringOffsets[holeRingIdx] - initialCoordIndex);
   }
+  // @ts-expect-error earcut typing is off. Should allow TypedArray but here
+  // only says number[]
   const triangles = earcut(slicedFlatCoords, holeIndices, dim);
 
   for (let i = 0; i < triangles.length; i++) {

--- a/src/earcut.ts
+++ b/src/earcut.ts
@@ -1,0 +1,58 @@
+import { earcut } from "@math.gl/polygon";
+import { PolygonData } from "./types";
+import { getLineStringChild, getPointChild, getPolygonChild } from "./utils";
+
+export function earcutPolygonArray(data: PolygonData): Uint32Array {
+  const trianglesResults: number[][] = [];
+  let outputSize = 0;
+  for (let geomIndex = 0; geomIndex < data.length; geomIndex++) {
+    const triangles = earcutSinglePolygon(data, geomIndex);
+    trianglesResults.push(triangles);
+    outputSize += triangles.length;
+  }
+
+  const outputArray = new Uint32Array(outputSize);
+  let idx = 0;
+  for (const triangles of trianglesResults) {
+    for (const value of triangles) {
+      outputArray[idx] = value;
+      idx += 1;
+    }
+  }
+
+  return outputArray;
+}
+
+function earcutSinglePolygon(data: PolygonData, geomIndex: number): number[] {
+  const geomOffsets = data.valueOffsets;
+  const rings = getPolygonChild(data);
+  const ringOffsets = rings.valueOffsets;
+
+  const coords = getLineStringChild(rings);
+  const dim = coords.type.listSize;
+  const flatCoords = getPointChild(coords);
+
+  const ringBegin = geomOffsets[geomIndex];
+  const ringEnd = geomOffsets[geomIndex + 1];
+
+  const coordsBegin = ringOffsets[ringBegin];
+  const coordsEnd = ringOffsets[ringEnd];
+
+  const slicedFlatCoords = flatCoords.values.subarray(
+    coordsBegin * dim,
+    coordsEnd * dim
+  );
+
+  const initialCoordIndex = ringOffsets[ringBegin];
+  const holeIndices = [];
+  for (let holeRingIdx = ringBegin + 1; holeRingIdx < ringEnd; holeRingIdx++) {
+    holeIndices.push(ringOffsets[holeRingIdx] - initialCoordIndex);
+  }
+  const triangles = earcut(slicedFlatCoords, holeIndices, dim);
+
+  for (let i = 0; i < triangles.length; i++) {
+    triangles[i] += initialCoordIndex;
+  }
+
+  return triangles;
+}

--- a/src/path-layer.ts
+++ b/src/path-layer.ts
@@ -7,7 +7,6 @@ import {
   GetPickingInfoParams,
   Layer,
   LayersList,
-  PickingInfo,
   Unit,
 } from "@deck.gl/core/typed";
 import { PathLayer } from "@deck.gl/layers/typed";
@@ -28,7 +27,11 @@ import {
   validateMultiLineStringType,
   validateVectorAccessors,
 } from "./utils.js";
-import { LineStringVector, MultiLineStringVector } from "./types.js";
+import {
+  GeoArrowPickingInfo,
+  LineStringVector,
+  MultiLineStringVector,
+} from "./types.js";
 import { EXTENSION_NAME } from "./constants.js";
 
 const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
@@ -141,7 +144,10 @@ export class GeoArrowPathLayer<
   static defaultProps = defaultProps;
   static layerName = "GeoArrowPathLayer";
 
-  getPickingInfo({ info, sourceLayer }: GetPickingInfoParams): PickingInfo {
+  getPickingInfo({
+    info,
+    sourceLayer,
+  }: GetPickingInfoParams): GeoArrowPickingInfo {
     const { data: table } = this.props;
 
     // Geometry index as rendered

--- a/src/scatterplot-layer.ts
+++ b/src/scatterplot-layer.ts
@@ -7,7 +7,6 @@ import {
   GetPickingInfoParams,
   Layer,
   LayersList,
-  PickingInfo,
   Unit,
 } from "@deck.gl/core/typed";
 import { ScatterplotLayer } from "@deck.gl/layers/typed";

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,8 @@ import * as arrow from "apache-arrow";
 
 export type InterleavedCoord = arrow.FixedSizeList<arrow.Float64>;
 export type SeparatedCoord = arrow.Struct<{
-  x: arrow.Float;
-  y: arrow.Float;
+  x: arrow.Float64;
+  y: arrow.Float64;
 }>;
 // TODO: support separated coords
 export type Coord = InterleavedCoord; // | SeparatedCoord;


### PR DESCRIPTION
Closes https://github.com/geoarrow/deck.gl-layers/issues/37. Also on the utah buildings example, timing went from 2s to 1.3s locally (just testing refreshing the chrome page).

Before:
<img width="649" alt="image" src="https://github.com/geoarrow/deck.gl-layers/assets/15164633/5eba7bb7-ce8e-44e7-b286-1e26d5fbfd54">

After: 
<img width="720" alt="image" src="https://github.com/geoarrow/deck.gl-layers/assets/15164633/806ba78d-5193-46d1-b4ee-a0e890b0bcfb">
