### PR TITLE
Fix setting defaultProps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.4",
+  "version": "0.3.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoarrow/deck.gl-layers",
-      "version": "0.3.0-beta.4",
+      "version": "0.3.0-beta.5",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "examples/*"
   ],
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.4",
+  "version": "0.3.0-beta.5",
   "type": "module",
   "description": "",
   "source": "src/index.ts",

--- a/src/arc-layer.ts
+++ b/src/arc-layer.ts
@@ -132,6 +132,12 @@ export class GeoArrowArcLayer<
       validatePointType(targetPosition.type);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getSourcePosition",
+      "getTargetPosition",
+    ]);
+
     const layers: ArcLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -143,13 +149,11 @@ export class GeoArrowArcLayer<
       const targetData = targetPosition.data[recordBatchIdx];
       const targetValues = getPointChild(targetData).values;
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getSourcePosition",
-        "getTargetPosition",
-      ]);
-
       const props: ArcLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/h3-hexagon-layer.ts
+++ b/src/h3-hexagon-layer.ts
@@ -71,6 +71,11 @@ export class GeoArrowH3HexagonLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getHexagon",
+    ]);
+
     const layers: H3HexagonLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -80,12 +85,11 @@ export class GeoArrowH3HexagonLayer<
       const hexData = hexagonColumn.data[recordBatchIdx];
       const hexValues = hexData.values;
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getHexagon",
-      ]);
-
       const props: H3HexagonLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/heatmap-layer.ts
+++ b/src/heatmap-layer.ts
@@ -96,6 +96,11 @@ export class GeoArrowHeatmapLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getPosition",
+    ]);
+
     const layers: HeatmapLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -106,12 +111,11 @@ export class GeoArrowHeatmapLayer<
       const flatCoordsData = getPointChild(geometryData);
       const flatCoordinateArray = flatCoordsData.values;
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getPosition",
-      ]);
-
       const props: HeatmapLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/path-layer.ts
+++ b/src/path-layer.ts
@@ -143,6 +143,11 @@ export class GeoArrowPathLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getPath",
+    ]);
+
     const layers: PathLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -156,12 +161,11 @@ export class GeoArrowPathLayer<
       const coordData = getPointChild(pointData);
       const flatCoordinateArray = coordData.values;
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getPath",
-      ]);
-
       const props: PathLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // used for picking purposes
@@ -207,6 +211,11 @@ export class GeoArrowPathLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getPath",
+    ]);
+
     const layers: PathLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -226,12 +235,11 @@ export class GeoArrowPathLayer<
       const multiLineStringToCoordOffsets =
         getMultiLineStringResolvedOffsets(multiLineStringData);
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getPath",
-      ]);
-
       const props: PathLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // used for picking purposes

--- a/src/scatterplot-layer.ts
+++ b/src/scatterplot-layer.ts
@@ -139,6 +139,11 @@ export class GeoArrowScatterplotLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getPosition",
+    ]);
+
     const layers: ScatterplotLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -149,12 +154,11 @@ export class GeoArrowScatterplotLayer<
       const flatCoordsData = getPointChild(geometryData);
       const flatCoordinateArray = flatCoordsData.values;
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getPosition",
-      ]);
-
       const props: ScatterplotLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes
@@ -200,6 +204,11 @@ export class GeoArrowScatterplotLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getPosition",
+    ]);
+
     const layers: ScatterplotLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -212,12 +221,11 @@ export class GeoArrowScatterplotLayer<
       const flatCoordsData = getPointChild(pointData);
       const flatCoordinateArray = flatCoordsData.values;
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getPosition",
-      ]);
-
       const props: ScatterplotLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/solid-polygon-layer.ts
+++ b/src/solid-polygon-layer.ts
@@ -142,6 +142,11 @@ export class GeoArrowSolidPolygonLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getPolygon",
+    ]);
+
     const layers: SolidPolygonLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -163,12 +168,11 @@ export class GeoArrowSolidPolygonLayer<
 
       const earcutTriangles = earcutPolygonArray(polygonData);
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getPolygon",
-      ]);
-
       const props: SolidPolygonLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // used for picking purposes
@@ -215,6 +219,11 @@ export class GeoArrowSolidPolygonLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getPolygon",
+    ]);
+
     const layers: SolidPolygonLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -250,12 +259,11 @@ export class GeoArrowSolidPolygonLayer<
       const resolvedMultiPolygonToCoordOffsets =
         getMultiPolygonResolvedOffsets(multiPolygonData);
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getPolygon",
-      ]);
-
       const props: SolidPolygonLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // used for picking purposes

--- a/src/text-layer.ts
+++ b/src/text-layer.ts
@@ -169,6 +169,12 @@ export class GeoArrowTextLayer<
       validateAccessors(this.props, table);
     }
 
+    // Exclude manually-set accessors
+    const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
+      "getPosition",
+      "getText",
+    ]);
+
     const layers: TextLayer[] = [];
     for (
       let recordBatchIdx = 0;
@@ -183,13 +189,11 @@ export class GeoArrowTextLayer<
       const textValues = textData.values;
       const characterOffsets = textData.valueOffsets;
 
-      // Exclude manually-set accessors
-      const [accessors, otherProps] = extractAccessorsFromProps(this.props, [
-        "getPosition",
-        "getText",
-      ]);
-
       const props: TextLayerProps = {
+        // Note: because this is a composite layer and not doing the rendering
+        // itself, we still have to pass in defaultProps as the default in this
+        // props object
+        ...defaultProps,
         ...otherProps,
 
         // // @ts-expect-error used for picking purposes


### PR DESCRIPTION
### Change list

- Fix setting `defaultProps` onto the generated `props` object. Because we're using composite layers and not doing the rendering in our own layers, we still have to pass in defaultProps as the default in the props object
- Remove `extractAccessorsFromProps` from the per-batch loop for perf
- Bump package version

The underlying fix for https://github.com/developmentseed/lonboard/issues/241