### PR TITLE
Fix default props (again)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.5",
+  "version": "0.3.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoarrow/deck.gl-layers",
-      "version": "0.3.0-beta.5",
+      "version": "0.3.0-beta.6",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "examples/*"
   ],
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.5",
+  "version": "0.3.0-beta.6",
   "type": "module",
   "description": "",
   "source": "src/index.ts",

--- a/src/arc-layer.ts
+++ b/src/arc-layer.ts
@@ -97,9 +97,14 @@ const {
   ..._defaultProps
 } = ArcLayer.defaultProps;
 
+// Default props added by us
+const ourDefaultProps = {
+  _validate: true,
+};
+
 const defaultProps: DefaultProps<GeoArrowArcLayerProps> = {
   ..._defaultProps,
-  _validate: true,
+  ...ourDefaultProps,
 };
 
 export class GeoArrowArcLayer<
@@ -151,9 +156,8 @@ export class GeoArrowArcLayer<
 
       const props: ArcLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/column-layer.ts
+++ b/src/column-layer.ts
@@ -89,9 +89,14 @@ const {
   ..._defaultProps
 } = ColumnLayer.defaultProps;
 
+// Default props added by us
+const ourDefaultProps = {
+  _validate: true,
+};
+
 const defaultProps: DefaultProps<GeoArrowColumnLayerProps> = {
   ..._defaultProps,
-  _validate: true,
+  ...ourDefaultProps,
 };
 
 /**
@@ -151,9 +156,8 @@ export class GeoArrowColumnLayer<
 
       const props: ColumnLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/h3-hexagon-layer.ts
+++ b/src/h3-hexagon-layer.ts
@@ -45,9 +45,14 @@ const {
   ..._defaultProps
 } = H3HexagonLayer.defaultProps;
 
+// Default props added by us
+const ourDefaultProps = {
+  _validate: true,
+};
+
 const defaultProps: DefaultProps<GeoArrowH3HexagonLayerProps> = {
   ..._defaultProps,
-  _validate: true,
+  ...ourDefaultProps,
 };
 
 export class GeoArrowH3HexagonLayer<
@@ -87,9 +92,8 @@ export class GeoArrowH3HexagonLayer<
 
       const props: H3HexagonLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/heatmap-layer.ts
+++ b/src/heatmap-layer.ts
@@ -59,9 +59,14 @@ const {
   ..._defaultProps
 } = HeatmapLayer.defaultProps;
 
+// Default props added by us
+const ourDefaultProps = {
+  _validate: true,
+};
+
 const defaultProps: DefaultProps<GeoArrowHeatmapLayerProps> = {
   ..._defaultProps,
-  _validate: true,
+  ...ourDefaultProps,
 };
 
 export class GeoArrowHeatmapLayer<
@@ -113,9 +118,8 @@ export class GeoArrowHeatmapLayer<
 
       const props: HeatmapLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/path-layer.ts
+++ b/src/path-layer.ts
@@ -1,4 +1,5 @@
 import {
+  Accessor,
   CompositeLayer,
   CompositeLayerProps,
   DefaultProps,
@@ -76,15 +77,21 @@ const {
   ..._defaultProps
 } = PathLayer.defaultProps;
 
+// Default props added by us
+const ourDefaultProps: Pick<GeoArrowPathLayerProps, "_pathType" | "_validate"> =
+  {
+    // Note: this diverges from upstream, where here we _default into_ binary
+    // rendering
+    // This instructs the layer to skip normalization and use the binary
+    // as-is
+    _pathType: "open",
+    _validate: true,
+  };
+
+// @ts-expect-error not sure why this is failing
 const defaultProps: DefaultProps<GeoArrowPathLayerProps> = {
   ..._defaultProps,
-  getWidth: { type: "accessor", value: 1 },
-  // Note: this diverges from upstream, where here we _default into_ binary
-  // rendering
-  // This instructs the layer to skip normalization and use the binary
-  // as-is
-  _pathType: "open",
-  _validate: true,
+  ...ourDefaultProps,
 };
 
 /**
@@ -163,9 +170,8 @@ export class GeoArrowPathLayer<
 
       const props: PathLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // used for picking purposes
@@ -237,9 +243,8 @@ export class GeoArrowPathLayer<
 
       const props: PathLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // used for picking purposes

--- a/src/scatterplot-layer.ts
+++ b/src/scatterplot-layer.ts
@@ -83,12 +83,17 @@ type _GeoArrowScatterplotLayerProps = {
 const {
   data: _data,
   getPosition: _getPosition,
-  ..._defaultProps
+  ..._upstreamDefaultProps
 } = ScatterplotLayer.defaultProps;
 
-const defaultProps: DefaultProps<GeoArrowScatterplotLayerProps> = {
-  ..._defaultProps,
+// Default props added by us
+const ourDefaultProps = {
   _validate: true,
+};
+
+const defaultProps: DefaultProps<GeoArrowScatterplotLayerProps> = {
+  ..._upstreamDefaultProps,
+  ...ourDefaultProps,
 };
 
 export class GeoArrowScatterplotLayer<
@@ -156,9 +161,8 @@ export class GeoArrowScatterplotLayer<
 
       const props: ScatterplotLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes
@@ -223,9 +227,8 @@ export class GeoArrowScatterplotLayer<
 
       const props: ScatterplotLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // @ts-expect-error used for picking purposes

--- a/src/solid-polygon-layer.ts
+++ b/src/solid-polygon-layer.ts
@@ -81,8 +81,11 @@ const {
   ..._defaultProps
 } = SolidPolygonLayer.defaultProps;
 
-const defaultProps: DefaultProps<GeoArrowSolidPolygonLayerProps> = {
-  ..._defaultProps,
+// Default props added by us
+const ourDefaultProps: Pick<
+  GeoArrowSolidPolygonLayerProps,
+  "_normalize" | "_windingOrder" | "_validate"
+> = {
   // Note: this diverges from upstream, where here we default to no
   // normalization
   _normalize: false,
@@ -90,6 +93,11 @@ const defaultProps: DefaultProps<GeoArrowSolidPolygonLayerProps> = {
   _windingOrder: "CCW",
 
   _validate: true,
+};
+
+const defaultProps: DefaultProps<GeoArrowSolidPolygonLayerProps> = {
+  ..._defaultProps,
+  ...ourDefaultProps,
 };
 
 export class GeoArrowSolidPolygonLayer<
@@ -170,9 +178,8 @@ export class GeoArrowSolidPolygonLayer<
 
       const props: SolidPolygonLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // used for picking purposes
@@ -261,9 +268,8 @@ export class GeoArrowSolidPolygonLayer<
 
       const props: SolidPolygonLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // used for picking purposes

--- a/src/text-layer.ts
+++ b/src/text-layer.ts
@@ -125,12 +125,20 @@ const {
   ..._defaultProps
 } = TextLayer.defaultProps;
 
-const defaultProps: DefaultProps<GeoArrowTextLayerProps> = {
-  ..._defaultProps,
+// Default props added by us
+const ourDefaultProps: Pick<
+  GeoArrowTextLayerProps,
+  "getTextAnchor" | "getAlignmentBaseline" | "getPixelOffset" | "_validate"
+> = {
   getTextAnchor: "middle",
   getAlignmentBaseline: "center",
   getPixelOffset: [0, 0],
   _validate: true,
+};
+
+const defaultProps: DefaultProps<GeoArrowTextLayerProps> = {
+  ..._defaultProps,
+  ...ourDefaultProps,
 };
 
 export class GeoArrowTextLayer<
@@ -191,9 +199,8 @@ export class GeoArrowTextLayer<
 
       const props: TextLayerProps = {
         // Note: because this is a composite layer and not doing the rendering
-        // itself, we still have to pass in defaultProps as the default in this
-        // props object
-        ...defaultProps,
+        // itself, we still have to pass in our defaultProps
+        ...ourDefaultProps,
         ...otherProps,
 
         // // @ts-expect-error used for picking purposes


### PR DESCRIPTION
Previously, when we were passing _all_ default props into the layer, e.g. the scatterplot layer was crashing and not rendering anything.

<img width="655" alt="image" src="https://github.com/geoarrow/deck.gl-layers/assets/15164633/b26d0880-4a19-4985-a144-97e1641bbf5e">

Instead, we should pass only _our_ default props down into the layer