### PR TITLE
 function accessors

### DIFF
--- a/examples/multilinestring/app.tsx
+++ b/examples/multilinestring/app.tsx
@@ -9,9 +9,9 @@ const GEOARROW_MULTILINESTRING_DATA =
   "http://localhost:8080/ne_10m_roads_north_america.feather";
 
 const INITIAL_VIEW_STATE = {
-  latitude: 20,
-  longitude: 0,
-  zoom: 2,
+  latitude: 40,
+  longitude: -90,
+  zoom: 4,
   bearing: 0,
   pitch: 0,
 };
@@ -24,16 +24,20 @@ const NAV_CONTROL_STYLE = {
   left: 10,
 };
 
-function Root() {
-  const onClick = (info) => {
-    if (info.object) {
-      // eslint-disable-next-line
-      alert(
-        `${info.object.properties.name} (${info.object.properties.abbrev})`
-      );
-    }
-  };
+// https://colorbrewer2.org/#type=sequential&scheme=PuBuGn&n=9
+const COLORS_LOOKUP = {
+  "3": [255, 247, 251],
+  "4": [236, 226, 240],
+  "5": [208, 209, 230],
+  "6": [166, 189, 219],
+  "7": [103, 169, 207],
+  "8": [54, 144, 192],
+  "9": [2, 129, 138],
+  "10": [1, 108, 89],
+  "11": [1, 70, 54],
+};
 
+function Root() {
   const [table, setTable] = useState<arrow.Table | null>(null);
 
   useEffect(() => {
@@ -58,17 +62,14 @@ function Root() {
       new GeoArrowPathLayer({
         id: "geoarrow-path",
         data: table,
-        // getPath: table.getC
-        // getPosition: table.getChild("geometry")!,
-        getColor:[255, 0, 0],
-        widthMinPixels: 0.2,
-        // getFillColor: [255, 0, 0],
-        // getFillColor: table.getChild("colors")!,
-        // getLineColor: table.getChild("colors")!,
-        radiusMinPixels: 4,
-        getPointRadius: 10,
-        pointRadiusMinPixels: 0.8,
-      })
+        getColor: ({ index, data }) => {
+          const recordBatch = data.data;
+          const row = recordBatch.get(index)!;
+          return COLORS_LOOKUP[row["scalerank"]];
+        },
+        widthMinPixels: 0.8,
+        pickable: true,
+      }),
     );
 
   return (

--- a/examples/point/app.tsx
+++ b/examples/point/app.tsx
@@ -54,12 +54,17 @@ function Root() {
       new GeoArrowScatterplotLayer({
         id: "geoarrow-points",
         data: table,
+        // Pre-computed colors in the original table
         getFillColor: table.getChild("colors")!,
-        radiusMinPixels: 1.5,
-        getPointRadius: 10,
-        pointRadiusMinPixels: 0.8,
+        opacity: 0.01,
+        getRadius: ({ index, data }) => {
+          const recordBatch = data.data;
+          const row = recordBatch.get(index)!;
+          return row["avg_d_kbps"] / 10;
+        },
+        radiusMinPixels: 0.1,
         pickable: true,
-      })
+      }),
     );
 
   return (

--- a/src/arc-layer.ts
+++ b/src/arc-layer.ts
@@ -164,12 +164,14 @@ export class GeoArrowArcLayer<
         ...ourDefaultProps,
         ...otherProps,
 
-        // @ts-expect-error used for picking purposes
+        // used for picking purposes
         recordBatchIdx,
         tableOffsets,
 
         id: `${this.props.id}-geoarrow-arc-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           length: sourceData.length,
           attributes: {
             getSourcePosition: {

--- a/src/column-layer.ts
+++ b/src/column-layer.ts
@@ -168,12 +168,14 @@ export class GeoArrowColumnLayer<
         ...ourDefaultProps,
         ...otherProps,
 
-        // @ts-expect-error used for picking purposes
+        // used for picking purposes
         recordBatchIdx,
         tableOffsets,
 
         id: `${this.props.id}-geoarrow-column-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           length: geometryData.length,
           attributes: {
             getPosition: {

--- a/src/h3-hexagon-layer.ts
+++ b/src/h3-hexagon-layer.ts
@@ -105,13 +105,15 @@ export class GeoArrowH3HexagonLayer<
         ...ourDefaultProps,
         ...otherProps,
 
-        // @ts-expect-error used for picking purposes
+        // used for picking purposes
         recordBatchIdx,
         tableOffsets,
 
         id: `${this.props.id}-geoarrow-arc-${recordBatchIdx}`,
 
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           length: hexData.length,
           attributes: {
             getHexagon: {

--- a/src/heatmap-layer.ts
+++ b/src/heatmap-layer.ts
@@ -128,12 +128,14 @@ export class GeoArrowHeatmapLayer<
         ...ourDefaultProps,
         ...otherProps,
 
-        // @ts-expect-error used for picking purposes
+        // used for picking purposes
         recordBatchIdx,
         tableOffsets,
 
         id: `${this.props.id}-geoarrow-heatmap-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           length: geometryData.length,
           attributes: {
             getPosition: {

--- a/src/path-layer.ts
+++ b/src/path-layer.ts
@@ -182,8 +182,9 @@ export class GeoArrowPathLayer<
 
         id: `${this.props.id}-geoarrow-path-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           length: lineStringData.length,
-          // @ts-expect-error
           startIndices: geomOffsets,
           attributes: {
             getPath: { value: flatCoordinateArray, size: nDim },
@@ -255,10 +256,14 @@ export class GeoArrowPathLayer<
         // used for picking purposes
         recordBatchIdx,
         tableOffsets,
-        invertedGeomOffsets: invertOffsets(geomOffsets),
 
         id: `${this.props.id}-geoarrow-path-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
+          // Map from expanded multi-geometry index to original index
+          // Used both in picking and for function callbacks
+          invertedGeomOffsets: invertOffsets(geomOffsets),
           // Note: this needs to be the length one level down.
           length: lineStringData.length,
           // Offsets into coordinateArray where each single-line string starts

--- a/src/picking.ts
+++ b/src/picking.ts
@@ -5,7 +5,9 @@ import { GeoArrowPickingInfo } from "./types";
 export interface GeoArrowExtraPickingProps {
   recordBatchIdx: number;
   tableOffsets: Uint32Array;
-  invertedGeomOffsets?: Uint8Array | Uint16Array | Uint32Array;
+  data: {
+    invertedGeomOffsets?: Uint8Array | Uint16Array | Uint32Array;
+  };
 }
 
 export function getPickingInfo(
@@ -22,8 +24,8 @@ export function getPickingInfo(
 
   // if a Multi- geometry dataset, map from the rendered index back to the
   // feature index
-  if (sourceLayer.props.invertedGeomOffsets) {
-    index = sourceLayer.props.invertedGeomOffsets[index];
+  if (sourceLayer.props.data.invertedGeomOffsets) {
+    index = sourceLayer.props.data.invertedGeomOffsets[index];
   }
 
   const recordBatchIdx = sourceLayer.props.recordBatchIdx;

--- a/src/scatterplot-layer.ts
+++ b/src/scatterplot-layer.ts
@@ -169,12 +169,14 @@ export class GeoArrowScatterplotLayer<
         ...ourDefaultProps,
         ...otherProps,
 
-        // @ts-expect-error used for picking purposes
+        // used for picking purposes
         recordBatchIdx,
         tableOffsets,
 
         id: `${this.props.id}-geoarrow-scatterplot-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           length: geometryData.length,
           attributes: {
             getPosition: {
@@ -237,13 +239,17 @@ export class GeoArrowScatterplotLayer<
         ...ourDefaultProps,
         ...otherProps,
 
-        // @ts-expect-error used for picking purposes
+        // used for picking purposes
         recordBatchIdx,
         tableOffsets,
-        invertedGeomOffsets: invertOffsets(geomOffsets),
 
         id: `${this.props.id}-geoarrow-scatterplot-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
+          // Map from expanded multi-geometry index to original index
+          // Used both in picking and for function callbacks
+          invertedGeomOffsets: invertOffsets(geomOffsets),
           // Note: this needs to be the length one level down.
           length: pointData.length,
           attributes: {

--- a/src/solid-polygon-layer.ts
+++ b/src/solid-polygon-layer.ts
@@ -419,6 +419,8 @@ export class GeoArrowSolidPolygonLayer<
 
         id: `${this.props.id}-geoarrow-point-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           // Number of geometries
           length: polygonData.length,
           // Offsets into coordinateArray where each polygon starts
@@ -510,10 +512,14 @@ export class GeoArrowSolidPolygonLayer<
         // used for picking purposes
         recordBatchIdx,
         tableOffsets: this.state.tableOffsets,
-        invertedGeomOffsets: invertOffsets(geomOffsets),
 
         id: `${this.props.id}-geoarrow-point-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
+          // Map from expanded multi-geometry index to original index
+          // Used both in picking and for function callbacks
+          invertedGeomOffsets: invertOffsets(geomOffsets),
           // Number of polygons
           // Note: this needs to be the length one level down, because we're
           // rendering the polygons, not the multipolygons
@@ -522,7 +528,6 @@ export class GeoArrowSolidPolygonLayer<
           //
           // Note that this is polygonToCoordOffsets and not geomToCoordOffsets
           // because we're rendering each part of the MultiPolygon individually
-          // @ts-expect-error
           startIndices: resolvedPolygonToCoordOffsets,
           attributes: {
             getPolygon: { value: flatCoordinateArray, size: nDim },

--- a/src/text-layer.ts
+++ b/src/text-layer.ts
@@ -211,14 +211,15 @@ export class GeoArrowTextLayer<
         ...ourDefaultProps,
         ...otherProps,
 
-        // // @ts-expect-error used for picking purposes
+        // used for picking purposes
         recordBatchIdx,
         tableOffsets,
 
         id: `${this.props.id}-geoarrow-heatmap-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           length: geometryData.length,
-          // @ts-expect-error
           startIndices: characterOffsets,
           attributes: {
             // Positions need to be expanded to be one per character!

--- a/src/trips-layer.ts
+++ b/src/trips-layer.ts
@@ -160,6 +160,8 @@ export class GeoArrowTripsLayer<
 
         id: `${this.props.id}-geoarrow-trip-${recordBatchIdx}`,
         data: {
+          // @ts-expect-error passed through to enable use by function accessors
+          data: table.batches[recordBatchIdx],
           length: lineStringData.length,
           // @ts-ignore
           startIndices: geomOffsets,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,56 @@
-import type { Accessor, Color, PickingInfo } from "@deck.gl/core/typed";
+import type { BinaryAttribute, Color, PickingInfo } from "@deck.gl/core/typed";
+import { TypedArray } from "@deck.gl/core/typed/types/types";
 import * as arrow from "apache-arrow";
+
+/**
+ * An individual layer's data
+ */
+export type GeoArrowLayerData<T> = {
+  data: T;
+  length: number;
+  attributes?: Record<string, TypedArray | Buffer | BinaryAttribute>;
+};
+
+/**
+ * Internal type for layer data handling, used in `wrapAccessorFunction`.
+ */
+export type _GeoArrowInternalLayerData<T> = GeoArrowLayerData<T> & {
+  /**
+   * A lookup table from expanded multi-geometry index to original index.
+   *
+   * This is omitted from the user-facing type because in `wrapAccessorFunction`
+   * in `utils.ts` we apply the lookup from "exploded" row to "original" row.
+   */
+  invertedGeomOffsets?: Uint8Array | Uint16Array | Uint32Array;
+};
+
+export type AccessorContext<T> = {
+  /** The current row index of the current iteration */
+  index: number;
+  /** The value of the `data` prop */
+  data: GeoArrowLayerData<T>;
+  /** A pre-allocated array. The accessor function can optionally fill data into this array and return it,
+   * instead of creating a new array for every object. In some browsers this improves performance significantly
+   * by reducing garbage collection. */
+  target: number[];
+};
+
+/**
+ * Internal type for layer data handling, used in `wrapAccessorFunction`.
+ */
+export type _InternalAccessorContext<T> = AccessorContext<T> & {
+  /** The value of the `data` prop */
+  data: _GeoArrowInternalLayerData<T>;
+};
+
+/** Function that returns a value for each object. */
+export type AccessorFunction<In, Out> = (
+  /** Contextual information of the current element. */
+  objectInfo: AccessorContext<In>,
+) => Out;
+
+/** Either a uniform value for all objects, or a function that returns a value for each object. */
+export type Accessor<In, Out> = Out | AccessorFunction<In, Out>;
 
 export type GeoArrowPickingInfo = PickingInfo & {
   object?: arrow.StructRowProxy;
@@ -7,8 +58,8 @@ export type GeoArrowPickingInfo = PickingInfo & {
 
 export type FloatAccessor =
   | arrow.Vector<arrow.Float>
-  | Accessor<arrow.Table, number>;
+  | Accessor<arrow.RecordBatch, number>;
 export type TimestampAccessor = arrow.Vector<arrow.List<arrow.Float>>;
 export type ColorAccessor =
   | arrow.Vector<arrow.FixedSizeList<arrow.Uint8>>
-  | Accessor<arrow.Table, Color | Color[]>;
+  | Accessor<arrow.RecordBatch, Color | Color[]>;


### PR DESCRIPTION
### Change list

- Pass the current `RecordBatch` into the `data` object so that it can be received by the user's function callback
- Wrap the user's function callback with our `wrapAccessorFunction` so that we can transparently handle mapping the "exploded" table from multi-geometry input back to the accurate original row.
- Updated example for both `point` and `multilinestring`
- Updated docs


Closes https://github.com/geoarrow/deck.gl-layers/issues/98