### PR TITLE
Wrap worker instantiation in try/catch; fix for non-served HTML files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "examples/*"
   ],
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.13",
+  "version": "0.3.0-beta.14",
   "type": "module",
   "description": "",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "examples/*"
   ],
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.12",
+  "version": "0.3.0-beta.13",
   "type": "module",
   "description": "",
   "source": "src/index.ts",

--- a/src/solid-polygon-layer.ts
+++ b/src/solid-polygon-layer.ts
@@ -354,7 +354,6 @@ export class GeoArrowSolidPolygonLayer<
     const { table } = this.state;
     if (!table) return null;
 
-    console.log("renderLayers");
     const polygonVector = getGeometryVector(table, EXTENSION_NAME.POLYGON);
     if (polygonVector !== null) {
       return this._renderLayersPolygon(polygonVector);
@@ -571,11 +570,7 @@ export class GeoArrowSolidPolygonLayer<
         });
       }
 
-      console.log("solid props", props);
-      console.log("this", this);
       const finalProps = this.getSubLayerProps(props);
-      console.log("final props", finalProps);
-
       const layer = new SolidPolygonLayer(finalProps);
       layers.push(layer);
     }

--- a/src/solid-polygon-layer.ts
+++ b/src/solid-polygon-layer.ts
@@ -155,12 +155,21 @@ export class GeoArrowSolidPolygonLayer<
       return null;
     }
 
-    const pool = Pool<FunctionThread>(
-      () => spawn(BlobWorker.fromText(workerText)),
-      8,
-    );
-    this.state.earcutWorkerPool = pool;
-    return this.state.earcutWorkerPool;
+    // Some environments are not able to execute `importScripts`
+    // E.g. on a non-served HTML file (e.g. from lonboard export) you get
+    // Uncaught DOMException: Failed to execute 'importScripts' on
+    // 'WorkerGlobalScope': The script at
+    // 'blob:null/4ffb0b98-d1bd-4d9e-be52-998f50829723' failed to load.
+    try {
+      const pool = Pool<FunctionThread>(
+        () => spawn(BlobWorker.fromText(workerText)),
+        8,
+      );
+      this.state.earcutWorkerPool = pool;
+      return this.state.earcutWorkerPool;
+    } catch (err) {
+      return null;
+    }
   }
 
   async finalizeState(context: LayerContext): Promise<void> {
@@ -337,6 +346,7 @@ export class GeoArrowSolidPolygonLayer<
     const { table } = this.state;
     if (!table) return null;
 
+    console.log("renderLayers");
     const polygonVector = getGeometryVector(table, EXTENSION_NAME.POLYGON);
     if (polygonVector !== null) {
       return this._renderLayersPolygon(polygonVector);
@@ -513,7 +523,7 @@ export class GeoArrowSolidPolygonLayer<
         recordBatchIdx,
         tableOffsets: this.state.tableOffsets,
 
-        id: `${this.props.id}-geoarrow-point-${recordBatchIdx}`,
+        id: `${this.props.id}-geoarrow-solid-polygon-multi-${recordBatchIdx}`,
         data: {
           // @ts-expect-error passed through to enable use by function accessors
           data: table.batches[recordBatchIdx],
@@ -553,7 +563,12 @@ export class GeoArrowSolidPolygonLayer<
         });
       }
 
-      const layer = new SolidPolygonLayer(this.getSubLayerProps(props));
+      console.log("solid props", props);
+      console.log("this", this);
+      const finalProps = this.getSubLayerProps(props);
+      console.log("final props", finalProps);
+
+      const layer = new SolidPolygonLayer(finalProps);
       layers.push(layer);
     }
 

--- a/src/solid-polygon-layer.ts
+++ b/src/solid-polygon-layer.ts
@@ -160,6 +160,14 @@ export class GeoArrowSolidPolygonLayer<
     // Uncaught DOMException: Failed to execute 'importScripts' on
     // 'WorkerGlobalScope': The script at
     // 'blob:null/4ffb0b98-d1bd-4d9e-be52-998f50829723' failed to load.
+    //
+    // Additionally, it appears impossible to _catch_ this exception (at least
+    // on Chrome), so we'll hack around this by additionally checking if the
+    // current file is served from file://
+    if (window?.location?.href.startsWith("file://")) {
+      return null;
+    }
+
     try {
       const pool = Pool<FunctionThread>(
         () => spawn(BlobWorker.fromText(workerText)),


### PR DESCRIPTION
Should fix errors when opening non-served local HTML files from lonboard