### PR TITLE
Fix picking in the polygon layer

### DIFF
--- a/examples/polygon/app.tsx
+++ b/examples/polygon/app.tsx
@@ -29,7 +29,7 @@ const NAV_CONTROL_STYLE = {
 function Root() {
   const onClick = (info: PickingInfo) => {
     if (info.object) {
-      console.log(JSON.stringify(info.object.toJSON()));
+      console.log(info.object["BoroName"]);
     }
   };
 
@@ -66,10 +66,10 @@ function Root() {
         extruded: false,
         wireframe: true,
         // getElevation: 0,
-        pickable: false,
+        pickable: true,
         positionFormat: "XY",
         _normalize: false,
-        autoHighlight: true,
+        autoHighlight: false,
         earcutWorkerUrl: new URL(
           "https://cdn.jsdelivr.net/npm/@geoarrow/geoarrow-js@0.3.0-beta.1/dist/earcut-worker.min.js",
         ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.11",
+  "version": "0.3.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoarrow/deck.gl-layers",
-      "version": "0.3.0-beta.11",
+      "version": "0.3.0-beta.14",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "examples/*"
   ],
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.14",
+  "version": "0.3.0-beta.15",
   "type": "module",
   "description": "",
   "source": "src/index.ts",

--- a/src/polygon-layer.ts
+++ b/src/polygon-layer.ts
@@ -185,7 +185,8 @@ export class GeoArrowPolygonLayer<
       sourceLayer: { props: GeoArrowExtraPickingProps };
     },
   ): GeoArrowPickingInfo {
-    return getPickingInfo(params, this.props.data);
+    // Propagate the picked info from the SolidPolygonLayer
+    return params.info;
   }
 
   renderLayers(): Layer<{}> | LayersList | null {
@@ -348,6 +349,8 @@ export class GeoArrowPolygonLayer<
           data: table,
           positionFormat,
           getPath,
+          // We only pick solid polygon layers, not the path layers
+          pickable: false,
         },
       );
 


### PR DESCRIPTION
This enables picking only on the underlying polygon layers, not also on the path layers. That's tracked in #114 