### PR TITLE
wip: handle picking stroke of polygon layer

### DIFF
--- a/src/path-layer.ts
+++ b/src/path-layer.ts
@@ -99,7 +99,10 @@ export class GeoArrowPathLayer<
       sourceLayer: { props: GeoArrowExtraPickingProps };
     },
   ): GeoArrowPickingInfo {
-    return getPickingInfo(params, this.props.data);
+    // Notes for handling
+
+    console.log(params);
+    const info = getPickingInfo(params, this.props.data);
   }
 
   renderLayers(): Layer<{}> | LayersList | null {

--- a/src/picking.ts
+++ b/src/picking.ts
@@ -41,6 +41,12 @@ export function getPickingInfo(
 
   // Update index to be _global_ index, not within the specific record batch
   index += currentBatchOffset;
+
+  // if (sourceLayer.props?.invertedOffsets) {
+  //   sourceLayer.props?.invertedOffsets[recordBatchIdx][index]
+  // }
+  // // const recordBatchIdx = ;
+
   return {
     ...info,
     index,


### PR DESCRIPTION
It would be nice to allow picking of both the underlying SolidPolygonLayer and the PathLayer. 

In https://github.com/geoarrow/deck.gl-layers/pull/113 we enable the picked index from the SolidPolygonLayer to be proxied to the consumer of the `PolygonLayer`. This works because the data structure of the PolygonLayer is exactly the same as the data structure of the SolidPolygonLayer. And the SolidPolygonLayer handles the index conversions when rendering MultiPolygons to screen (in `invertOffsets`).

The thing is, with the PathLayer we need to apply `invertOffsets` _twice_. The PathLayer returns a single index into the _expanded_ PathLayer table. But we need to map that back into the original polygon table passed in by the user.
