### PR TITLE
Publish beta with fixed PolygonLayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "examples/*"
   ],
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.15",
+  "version": "0.3.0-beta.16",
   "type": "module",
   "description": "",
   "source": "src/index.ts",


### PR DESCRIPTION
With this fix: https://github.com/geoarrow/deck.gl-layers/pull/113