### PR TITLE
Prefer user input over defaults

### DIFF
--- a/src/column-layer.ts
+++ b/src/column-layer.ts
@@ -44,7 +44,6 @@ type _GeoArrowColumnLayerProps = {
 
   /**
    * Method called to retrieve the position of each column.
-   * @default object => object.position
    */
   getPosition?: ga.vector.PointVector;
 

--- a/src/heatmap-layer.ts
+++ b/src/heatmap-layer.ts
@@ -80,17 +80,23 @@ export class GeoArrowHeatmapLayer<
   renderLayers(): Layer<{}> | LayersList | null {
     const { data: table } = this.props;
 
-    const pointVector = getGeometryVector(table, EXTENSION_NAME.POINT);
-    if (pointVector !== null) {
-      return this._renderLayersPoint(pointVector);
-    }
+    if (this.props.getPosition !== undefined) {
+      const geometryColumn = this.props.getPosition;
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isPointVector(geometryColumn)
+      ) {
+        return this._renderLayersPoint(geometryColumn);
+      }
 
-    const geometryColumn = this.props.getPosition;
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isPointVector(geometryColumn)
-    ) {
-      return this._renderLayersPoint(geometryColumn);
+      throw new Error(
+        "getPosition should pass in an arrow Vector of Point type",
+      );
+    } else {
+      const pointVector = getGeometryVector(table, EXTENSION_NAME.POINT);
+      if (pointVector !== null) {
+        return this._renderLayersPoint(pointVector);
+      }
     }
 
     throw new Error("getPosition not GeoArrow point");

--- a/src/path-layer.ts
+++ b/src/path-layer.ts
@@ -105,35 +105,41 @@ export class GeoArrowPathLayer<
   renderLayers(): Layer<{}> | LayersList | null {
     const { data: table } = this.props;
 
-    const lineStringVector = getGeometryVector(
-      table,
-      EXTENSION_NAME.LINESTRING,
-    );
-    if (lineStringVector !== null) {
-      return this._renderLayersLineString(lineStringVector);
-    }
+    if (this.props.getPath !== undefined) {
+      const geometryColumn = this.props.getPath;
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isLineStringVector(geometryColumn)
+      ) {
+        return this._renderLayersLineString(geometryColumn);
+      }
 
-    const multiLineStringVector = getGeometryVector(
-      table,
-      EXTENSION_NAME.MULTILINESTRING,
-    );
-    if (multiLineStringVector !== null) {
-      return this._renderLayersMultiLineString(multiLineStringVector);
-    }
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isMultiLineStringVector(geometryColumn)
+      ) {
+        return this._renderLayersMultiLineString(geometryColumn);
+      }
 
-    const geometryColumn = this.props.getPath;
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isLineStringVector(geometryColumn)
-    ) {
-      return this._renderLayersLineString(geometryColumn);
-    }
+      throw new Error(
+        "getPath should be an arrow Vector of LineString or MultiLineString type",
+      );
+    } else {
+      const lineStringVector = getGeometryVector(
+        table,
+        EXTENSION_NAME.LINESTRING,
+      );
+      if (lineStringVector !== null) {
+        return this._renderLayersLineString(lineStringVector);
+      }
 
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isMultiLineStringVector(geometryColumn)
-    ) {
-      return this._renderLayersMultiLineString(geometryColumn);
+      const multiLineStringVector = getGeometryVector(
+        table,
+        EXTENSION_NAME.MULTILINESTRING,
+      );
+      if (multiLineStringVector !== null) {
+        return this._renderLayersMultiLineString(multiLineStringVector);
+      }
     }
 
     throw new Error("getPath not GeoArrow LineString or MultiLineString");

--- a/src/point-cloud-layer.ts
+++ b/src/point-cloud-layer.ts
@@ -101,20 +101,26 @@ export class GeoArrowPointCloudLayer<
   renderLayers(): Layer<{}> | LayersList | null {
     const { data: table } = this.props;
 
-    const pointVector = getGeometryVector(table, EXTENSION_NAME.POINT);
-    if (pointVector !== null) {
-      return this._renderLayersPoint(pointVector);
+    if (this.props.getPosition !== undefined) {
+      const geometryColumn = this.props.getPosition;
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isPointVector(geometryColumn)
+      ) {
+        return this._renderLayersPoint(geometryColumn);
+      }
+
+      throw new Error(
+        "getPosition should pass in an arrow Vector of Point type",
+      );
+    } else {
+      const pointVector = getGeometryVector(table, EXTENSION_NAME.POINT);
+      if (pointVector !== null) {
+        return this._renderLayersPoint(pointVector);
+      }
     }
 
-    const geometryColumn = this.props.getPosition;
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isPointVector(geometryColumn)
-    ) {
-      return this._renderLayersPoint(geometryColumn);
-    }
-
-    throw new Error("geometryColumn not GeoArrow point");
+    throw new Error("getPosition not GeoArrow point");
   }
 
   _renderLayersPoint(

--- a/src/polygon-layer.ts
+++ b/src/polygon-layer.ts
@@ -192,26 +192,32 @@ export class GeoArrowPolygonLayer<
   renderLayers(): Layer<{}> | LayersList | null {
     const { data: table } = this.props;
 
-    const polygonVector = getGeometryVector(table, EXTENSION_NAME.POLYGON);
-    if (polygonVector !== null) {
-      return this._renderLayers(polygonVector);
-    }
+    if (this.props.getPolygon !== undefined) {
+      const geometryColumn = this.props.getPolygon;
+      if (ga.vector.isPolygonVector(geometryColumn)) {
+        return this._renderLayers(geometryColumn);
+      }
 
-    const multiPolygonVector = getGeometryVector(
-      table,
-      EXTENSION_NAME.MULTIPOLYGON,
-    );
-    if (multiPolygonVector !== null) {
-      return this._renderLayers(multiPolygonVector);
-    }
+      if (ga.vector.isMultiPolygonVector(geometryColumn)) {
+        return this._renderLayers(geometryColumn);
+      }
 
-    const geometryColumn = this.props.getPolygon;
-    if (ga.vector.isPolygonVector(geometryColumn)) {
-      return this._renderLayers(geometryColumn);
-    }
+      throw new Error(
+        "getPolygon should be an arrow Vector of Polygon or MultiPolygon type",
+      );
+    } else {
+      const polygonVector = getGeometryVector(table, EXTENSION_NAME.POLYGON);
+      if (polygonVector !== null) {
+        return this._renderLayers(polygonVector);
+      }
 
-    if (ga.vector.isMultiPolygonVector(geometryColumn)) {
-      return this._renderLayers(geometryColumn);
+      const multiPolygonVector = getGeometryVector(
+        table,
+        EXTENSION_NAME.MULTIPOLYGON,
+      );
+      if (multiPolygonVector !== null) {
+        return this._renderLayers(multiPolygonVector);
+      }
     }
 
     throw new Error("geometryColumn not Polygon or MultiPolygon");

--- a/src/scatterplot-layer.ts
+++ b/src/scatterplot-layer.ts
@@ -106,32 +106,38 @@ export class GeoArrowScatterplotLayer<
   renderLayers(): Layer<{}> | LayersList | null {
     const { data: table } = this.props;
 
-    const pointVector = getGeometryVector(table, EXTENSION_NAME.POINT);
-    if (pointVector !== null) {
-      return this._renderLayersPoint(pointVector);
-    }
+    if (this.props.getPosition !== undefined) {
+      const geometryColumn = this.props.getPosition;
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isPointVector(geometryColumn)
+      ) {
+        return this._renderLayersPoint(geometryColumn);
+      }
 
-    const multiPointVector = getGeometryVector(
-      table,
-      EXTENSION_NAME.MULTIPOINT,
-    );
-    if (multiPointVector !== null) {
-      return this._renderLayersMultiPoint(multiPointVector);
-    }
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isMultiPointVector(geometryColumn)
+      ) {
+        return this._renderLayersMultiPoint(geometryColumn);
+      }
 
-    const geometryColumn = this.props.getPosition;
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isPointVector(geometryColumn)
-    ) {
-      return this._renderLayersPoint(geometryColumn);
-    }
+      throw new Error(
+        "getPosition should pass in an arrow Vector of Point or MultiPoint type",
+      );
+    } else {
+      const pointVector = getGeometryVector(table, EXTENSION_NAME.POINT);
+      if (pointVector !== null) {
+        return this._renderLayersPoint(pointVector);
+      }
 
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isMultiPointVector(geometryColumn)
-    ) {
-      return this._renderLayersMultiPoint(geometryColumn);
+      const multiPointVector = getGeometryVector(
+        table,
+        EXTENSION_NAME.MULTIPOINT,
+      );
+      if (multiPointVector !== null) {
+        return this._renderLayersMultiPoint(multiPointVector);
+      }
     }
 
     throw new Error("getPosition not GeoArrow point or multipoint");

--- a/src/solid-polygon-layer.ts
+++ b/src/solid-polygon-layer.ts
@@ -354,32 +354,38 @@ export class GeoArrowSolidPolygonLayer<
     const { table } = this.state;
     if (!table) return null;
 
-    const polygonVector = getGeometryVector(table, EXTENSION_NAME.POLYGON);
-    if (polygonVector !== null) {
-      return this._renderLayersPolygon(polygonVector);
-    }
+    if (this.props.getPolygon !== undefined) {
+      const geometryColumn = this.props.getPolygon;
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isPolygonVector(geometryColumn)
+      ) {
+        return this._renderLayersPolygon(geometryColumn);
+      }
 
-    const MultiPolygonVector = getGeometryVector(
-      table,
-      EXTENSION_NAME.MULTIPOLYGON,
-    );
-    if (MultiPolygonVector !== null) {
-      return this._renderLayersMultiPolygon(MultiPolygonVector);
-    }
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isMultiPolygonVector(geometryColumn)
+      ) {
+        return this._renderLayersMultiPolygon(geometryColumn);
+      }
 
-    const geometryColumn = this.props.getPolygon;
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isPolygonVector(geometryColumn)
-    ) {
-      return this._renderLayersPolygon(geometryColumn);
-    }
+      throw new Error(
+        "getPolygon should be an arrow Vector of Polygon or MultiPolygon type",
+      );
+    } else {
+      const polygonVector = getGeometryVector(table, EXTENSION_NAME.POLYGON);
+      if (polygonVector !== null) {
+        return this._renderLayersPolygon(polygonVector);
+      }
 
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isMultiPolygonVector(geometryColumn)
-    ) {
-      return this._renderLayersMultiPolygon(geometryColumn);
+      const MultiPolygonVector = getGeometryVector(
+        table,
+        EXTENSION_NAME.MULTIPOLYGON,
+      );
+      if (MultiPolygonVector !== null) {
+        return this._renderLayersMultiPolygon(MultiPolygonVector);
+      }
     }
 
     throw new Error("getPolygon not GeoArrow Polygon or MultiPolygon");

--- a/src/text-layer.ts
+++ b/src/text-layer.ts
@@ -158,17 +158,23 @@ export class GeoArrowTextLayer<
   renderLayers(): Layer<{}> | LayersList | null {
     const { data: table } = this.props;
 
-    const pointVector = getGeometryVector(table, EXTENSION_NAME.POINT);
-    if (pointVector !== null) {
-      return this._renderLayersPoint(pointVector);
-    }
+    if (this.props.getPosition !== undefined) {
+      const geometryColumn = this.props.getPosition;
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isPointVector(geometryColumn)
+      ) {
+        return this._renderLayersPoint(geometryColumn);
+      }
 
-    const geometryColumn = this.props.getPosition;
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isPointVector(geometryColumn)
-    ) {
-      return this._renderLayersPoint(geometryColumn);
+      throw new Error(
+        "getPosition should pass in an arrow Vector of Point type",
+      );
+    } else {
+      const pointVector = getGeometryVector(table, EXTENSION_NAME.POINT);
+      if (pointVector !== null) {
+        return this._renderLayersPoint(pointVector);
+      }
     }
 
     throw new Error("getPosition not GeoArrow point");

--- a/src/trips-layer.ts
+++ b/src/trips-layer.ts
@@ -96,20 +96,24 @@ export class GeoArrowTripsLayer<
   renderLayers(): Layer<{}> | LayersList | null {
     const { data: table } = this.props;
 
-    const lineStringVector = getGeometryVector(
-      table,
-      EXTENSION_NAME.LINESTRING,
-    );
-    if (lineStringVector !== null) {
-      return this._renderLayersLineString(lineStringVector);
-    }
+    if (this.props.getPath !== undefined) {
+      const geometryColumn = this.props.getPath;
+      if (
+        geometryColumn !== undefined &&
+        ga.vector.isLineStringVector(geometryColumn)
+      ) {
+        return this._renderLayersLineString(geometryColumn);
+      }
 
-    const geometryColumn = this.props.getPath;
-    if (
-      geometryColumn !== undefined &&
-      ga.vector.isLineStringVector(geometryColumn)
-    ) {
-      return this._renderLayersLineString(geometryColumn);
+      throw new Error("getPath should be an arrow Vector of LineString type");
+    } else {
+      const lineStringVector = getGeometryVector(
+        table,
+        EXTENSION_NAME.LINESTRING,
+      );
+      if (lineStringVector !== null) {
+        return this._renderLayersLineString(lineStringVector);
+      }
     }
 
     throw new Error("getPath not GeoArrow LineString");


### PR DESCRIPTION
E.g. if a user passes in `getPosition: table.getChild(...)`, the layer should never render a different column, even if that other column has geoarrow metadata.

This also adds explicit checking for the geometry prop. So passing a function into `getPosition` should always error.

This is a fix for https://github.com/geoarrow/deck.gl-layers/issues/116, cc @jaredlander