### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "examples/*"
   ],
   "name": "@geoarrow/deck.gl-layers",
-  "version": "0.3.0-beta.16",
+  "version": "0.3.0-beta.17",
   "type": "module",
   "description": "",
   "source": "src/index.ts",


### PR DESCRIPTION
publishing a new alpha version with deck.gl v9. After this we should probably try to use the upstream fork instead https://github.com/visgl/deck.gl-community