### PR TITLE
Support separated (struct) coordinates for all applicable layers

### DIFF
--- a/src/layers/arc-layer.ts
+++ b/src/layers/arc-layer.ts
@@ -15,7 +15,12 @@ import { ArcLayer } from "@deck.gl/layers";
 import type { ArcLayerProps } from "@deck.gl/layers";
 import * as arrow from "apache-arrow";
 import * as ga from "@geoarrow/geoarrow-js";
-import { assignAccessor, convertStructToFixedSizeList, extractAccessorsFromProps, isGeomSeparate } from "../utils/utils";
+import {
+  assignAccessor,
+  convertStructToFixedSizeList,
+  extractAccessorsFromProps,
+  isGeomSeparate,
+} from "../utils/utils";
 import { child } from "@geoarrow/geoarrow-js";
 import {
   GeoArrowExtraPickingProps,

--- a/src/layers/arc-layer.ts
+++ b/src/layers/arc-layer.ts
@@ -15,7 +15,7 @@ import { ArcLayer } from "@deck.gl/layers";
 import type { ArcLayerProps } from "@deck.gl/layers";
 import * as arrow from "apache-arrow";
 import * as ga from "@geoarrow/geoarrow-js";
-import { assignAccessor, extractAccessorsFromProps } from "../utils/utils";
+import { assignAccessor, convertStructToFixedSizeList, extractAccessorsFromProps, isGeomSeparate } from "../utils/utils";
 import { child } from "@geoarrow/geoarrow-js";
 import {
   GeoArrowExtraPickingProps,
@@ -157,9 +157,15 @@ export class GeoArrowArcLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const sourceData = sourcePosition.data[recordBatchIdx];
+      let sourceData = sourcePosition.data[recordBatchIdx];
+      if (isGeomSeparate(sourceData)) {
+        sourceData = convertStructToFixedSizeList(sourceData);
+      }
       const sourceValues = child.getPointChild(sourceData).values;
-      const targetData = targetPosition.data[recordBatchIdx];
+      let targetData = targetPosition.data[recordBatchIdx];
+      if (isGeomSeparate(targetData)) {
+        targetData = convertStructToFixedSizeList(targetData);
+      }
       const targetValues = child.getPointChild(targetData).values;
 
       const props: ArcLayerProps = {

--- a/src/layers/column-layer.ts
+++ b/src/layers/column-layer.ts
@@ -16,8 +16,10 @@ import type { ColumnLayerProps } from "@deck.gl/layers";
 import * as arrow from "apache-arrow";
 import {
   assignAccessor,
+  convertStructToFixedSizeList,
   extractAccessorsFromProps,
   getGeometryVector,
+  isGeomSeparate,
 } from "../utils/utils";
 import * as ga from "@geoarrow/geoarrow-js";
 import { ColorAccessor, FloatAccessor, GeoArrowPickingInfo } from "../types";
@@ -161,7 +163,10 @@ export class GeoArrowColumnLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const geometryData = geometryColumn.data[recordBatchIdx];
+      let geometryData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(geometryData)) {
+        geometryData = convertStructToFixedSizeList(geometryData);
+      }
       const flatCoordsData = ga.child.getPointChild(geometryData);
       const flatCoordinateArray = flatCoordsData.values;
 

--- a/src/layers/heatmap-layer.ts
+++ b/src/layers/heatmap-layer.ts
@@ -16,8 +16,10 @@ import * as arrow from "apache-arrow";
 import * as ga from "@geoarrow/geoarrow-js";
 import {
   assignAccessor,
+  convertStructToFixedSizeList,
   extractAccessorsFromProps,
   getGeometryVector,
+  isGeomSeparate,
 } from "../utils/utils";
 import { FloatAccessor } from "../types";
 import { EXTENSION_NAME } from "../constants";
@@ -128,7 +130,10 @@ export class GeoArrowHeatmapLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const geometryData = geometryColumn.data[recordBatchIdx];
+      let geometryData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(geometryData)) {
+        geometryData = convertStructToFixedSizeList(geometryData);
+      }
       const flatCoordsData = ga.child.getPointChild(geometryData);
       const flatCoordinateArray = flatCoordsData.values;
 

--- a/src/layers/path-layer.ts
+++ b/src/layers/path-layer.ts
@@ -19,8 +19,10 @@ import {
   assignAccessor,
   extractAccessorsFromProps,
   getGeometryVector,
+  getInterleavedLineString,
   getMultiLineStringResolvedOffsets,
   invertOffsets,
+  isGeomSeparate,
 } from "../utils/utils";
 import {
   GeoArrowExtraPickingProps,
@@ -172,7 +174,10 @@ export class GeoArrowPathLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const lineStringData = geometryColumn.data[recordBatchIdx];
+      let lineStringData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(lineStringData)) {
+        lineStringData = getInterleavedLineString(lineStringData);
+      }
       const geomOffsets = lineStringData.valueOffsets;
       const pointData = ga.child.getLineStringChild(lineStringData);
       const nDim = pointData.type.listSize;
@@ -243,8 +248,11 @@ export class GeoArrowPathLayer<
       recordBatchIdx++
     ) {
       const multiLineStringData = geometryColumn.data[recordBatchIdx];
-      const lineStringData =
+      let lineStringData =
         ga.child.getMultiLineStringChild(multiLineStringData);
+      if (isGeomSeparate(lineStringData)) {
+        lineStringData = getInterleavedLineString(lineStringData);
+      }
       const pointData = ga.child.getLineStringChild(lineStringData);
       const coordData = ga.child.getPointChild(pointData);
 

--- a/src/layers/point-cloud-layer.ts
+++ b/src/layers/point-cloud-layer.ts
@@ -19,8 +19,10 @@ import * as arrow from "apache-arrow";
 import * as ga from "@geoarrow/geoarrow-js";
 import {
   assignAccessor,
+  convertStructToFixedSizeList,
   extractAccessorsFromProps,
   getGeometryVector,
+  isGeomSeparate,
 } from "../utils/utils";
 import {
   GeoArrowExtraPickingProps,
@@ -156,7 +158,10 @@ export class GeoArrowPointCloudLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const geometryData = geometryColumn.data[recordBatchIdx];
+      let geometryData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(geometryData)) {
+        geometryData = convertStructToFixedSizeList(geometryData);
+      }
       const flatCoordsData = ga.child.getPointChild(geometryData);
       const flatCoordinateArray = flatCoordsData.values;
 

--- a/src/layers/scatterplot-layer.ts
+++ b/src/layers/scatterplot-layer.ts
@@ -17,9 +17,11 @@ import * as arrow from "apache-arrow";
 import * as ga from "@geoarrow/geoarrow-js";
 import {
   assignAccessor,
+  convertStructToFixedSizeList,
   extractAccessorsFromProps,
   getGeometryVector,
   invertOffsets,
+  isGeomSeparate,
 } from "../utils/utils";
 import {
   GeoArrowExtraPickingProps,
@@ -169,7 +171,10 @@ export class GeoArrowScatterplotLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const geometryData = geometryColumn.data[recordBatchIdx];
+      let geometryData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(geometryData)) {
+        geometryData = convertStructToFixedSizeList(geometryData);
+      }
       const flatCoordsData = ga.child.getPointChild(geometryData);
       const flatCoordinateArray = flatCoordsData.values;
 
@@ -238,7 +243,10 @@ export class GeoArrowScatterplotLayer<
       recordBatchIdx++
     ) {
       const multiPointData = geometryColumn.data[recordBatchIdx];
-      const pointData = ga.child.getMultiPointChild(multiPointData);
+      let pointData = ga.child.getMultiPointChild(multiPointData);
+      if (isGeomSeparate(pointData)) {
+        pointData = convertStructToFixedSizeList(pointData);
+      }
       const geomOffsets = multiPointData.valueOffsets;
       const flatCoordsData = ga.child.getPointChild(pointData);
       const flatCoordinateArray = flatCoordsData.values;

--- a/src/layers/solid-polygon-layer.ts
+++ b/src/layers/solid-polygon-layer.ts
@@ -21,9 +21,11 @@ import {
   assignAccessor,
   extractAccessorsFromProps,
   getGeometryVector,
+  getInterleavedPolygon,
   getMultiPolygonResolvedOffsets,
   getPolygonResolvedOffsets,
   invertOffsets,
+  isGeomSeparate,
 } from "../utils/utils";
 import {
   GeoArrowExtraPickingProps,
@@ -249,7 +251,10 @@ export class GeoArrowSolidPolygonLayer<
       recordBatchIdx < geometryColumn.data.length;
       recordBatchIdx++
     ) {
-      const polygonData = geometryColumn.data[recordBatchIdx];
+      let polygonData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(polygonData)) {
+        polygonData = getInterleavedPolygon(polygonData);
+      }
       const [preparedPolygonData, arrayBuffers] = ga.worker.preparePostMessage(
         polygonData,
         true,
@@ -278,7 +283,10 @@ export class GeoArrowSolidPolygonLayer<
       recordBatchIdx < geometryColumn.data.length;
       recordBatchIdx++
     ) {
-      const polygonData = geometryColumn.data[recordBatchIdx];
+      let polygonData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(polygonData)) {
+        polygonData = getInterleavedPolygon(polygonData);
+      }
       result[recordBatchIdx] = ga.algorithm.earcut(polygonData);
     }
 
@@ -303,7 +311,10 @@ export class GeoArrowSolidPolygonLayer<
       recordBatchIdx++
     ) {
       const multiPolygonData = geometryColumn.data[recordBatchIdx];
-      const polygonData = ga.child.getMultiPolygonChild(multiPolygonData);
+      let polygonData = ga.child.getMultiPolygonChild(multiPolygonData);
+      if (isGeomSeparate(polygonData)) {
+        polygonData = getInterleavedPolygon(polygonData);
+      }
       const [preparedPolygonData, arrayBuffers] = ga.worker.preparePostMessage(
         polygonData,
         true,
@@ -333,7 +344,10 @@ export class GeoArrowSolidPolygonLayer<
       recordBatchIdx++
     ) {
       const multiPolygonData = geometryColumn.data[recordBatchIdx];
-      const polygonData = ga.child.getMultiPolygonChild(multiPolygonData);
+      let polygonData = ga.child.getMultiPolygonChild(multiPolygonData);
+      if (isGeomSeparate(polygonData)) {
+        polygonData = getInterleavedPolygon(polygonData);
+      }
       result[recordBatchIdx] = ga.algorithm.earcut(polygonData);
     }
 
@@ -417,7 +431,10 @@ export class GeoArrowSolidPolygonLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const polygonData = geometryColumn.data[recordBatchIdx];
+      let polygonData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(polygonData)) {
+        polygonData = getInterleavedPolygon(polygonData);
+      }
       const ringData = ga.child.getPolygonChild(polygonData);
       const pointData = ga.child.getLineStringChild(ringData);
       const coordData = ga.child.getPointChild(pointData);
@@ -499,7 +516,10 @@ export class GeoArrowSolidPolygonLayer<
       recordBatchIdx++
     ) {
       const multiPolygonData = geometryColumn.data[recordBatchIdx];
-      const polygonData = ga.child.getMultiPolygonChild(multiPolygonData);
+      let polygonData = ga.child.getMultiPolygonChild(multiPolygonData);
+      if (isGeomSeparate(polygonData)) {
+        polygonData = getInterleavedPolygon(polygonData);
+      }
       const ringData = ga.child.getPolygonChild(polygonData);
       const pointData = ga.child.getLineStringChild(ringData);
       const coordData = ga.child.getPointChild(pointData);

--- a/src/layers/solid-polygon-layer.ts
+++ b/src/layers/solid-polygon-layer.ts
@@ -252,6 +252,8 @@ export class GeoArrowSolidPolygonLayer<
       recordBatchIdx++
     ) {
       let polygonData = geometryColumn.data[recordBatchIdx];
+      // TODO: Note here that [when applicable] we do this conversion twice -
+      // one for triangulation (earcut) here and the other for rendering later.
       if (isGeomSeparate(polygonData)) {
         polygonData = getInterleavedPolygon(polygonData);
       }
@@ -284,6 +286,8 @@ export class GeoArrowSolidPolygonLayer<
       recordBatchIdx++
     ) {
       let polygonData = geometryColumn.data[recordBatchIdx];
+      // TODO: Note here that [when applicable] we do this conversion twice -
+      // one for triangulation (earcut) here and the other for rendering later.
       if (isGeomSeparate(polygonData)) {
         polygonData = getInterleavedPolygon(polygonData);
       }
@@ -312,6 +316,8 @@ export class GeoArrowSolidPolygonLayer<
     ) {
       const multiPolygonData = geometryColumn.data[recordBatchIdx];
       let polygonData = ga.child.getMultiPolygonChild(multiPolygonData);
+      // TODO: Note here that [when applicable] we do this conversion twice -
+      // one for triangulation (earcut) here and the other for rendering later.
       if (isGeomSeparate(polygonData)) {
         polygonData = getInterleavedPolygon(polygonData);
       }
@@ -345,6 +351,8 @@ export class GeoArrowSolidPolygonLayer<
     ) {
       const multiPolygonData = geometryColumn.data[recordBatchIdx];
       let polygonData = ga.child.getMultiPolygonChild(multiPolygonData);
+      // TODO: Note here that [when applicable] we do this conversion twice -
+      // one for triangulation (earcut) here and the other for rendering later.
       if (isGeomSeparate(polygonData)) {
         polygonData = getInterleavedPolygon(polygonData);
       }

--- a/src/layers/text-layer.ts
+++ b/src/layers/text-layer.ts
@@ -17,9 +17,11 @@ import * as arrow from "apache-arrow";
 import * as ga from "@geoarrow/geoarrow-js";
 import {
   assignAccessor,
+  convertStructToFixedSizeList,
   expandArrayToCoords,
   extractAccessorsFromProps,
   getGeometryVector,
+  isGeomSeparate,
 } from "../utils/utils";
 import {
   GeoArrowExtraPickingProps,
@@ -207,7 +209,10 @@ export class GeoArrowTextLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const geometryData = geometryColumn.data[recordBatchIdx];
+      let geometryData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(geometryData)) {
+        geometryData = convertStructToFixedSizeList(geometryData);
+      }
       const flatCoordsData = ga.child.getPointChild(geometryData);
       const flatCoordinateArray = flatCoordsData.values;
       const textData = this.props.getText.data[recordBatchIdx];

--- a/src/layers/trips-layer.ts
+++ b/src/layers/trips-layer.ts
@@ -17,6 +17,8 @@ import {
   assignAccessor,
   extractAccessorsFromProps,
   getGeometryVector,
+  getInterleavedLineString,
+  isGeomSeparate,
 } from "../utils/utils";
 import { TimestampAccessor, ColorAccessor, FloatAccessor } from "../types";
 import {
@@ -146,7 +148,10 @@ export class GeoArrowTripsLayer<
       recordBatchIdx < table.batches.length;
       recordBatchIdx++
     ) {
-      const lineStringData = geometryColumn.data[recordBatchIdx];
+      let lineStringData = geometryColumn.data[recordBatchIdx];
+      if (isGeomSeparate(lineStringData)) {
+        lineStringData = getInterleavedLineString(lineStringData);
+      }
       const geomOffsets = lineStringData.valueOffsets;
       const pointData = ga.child.getLineStringChild(lineStringData);
       const nDim = pointData.type.listSize;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -108,7 +108,7 @@ export function isGeomSeparate(data: arrow.Data): boolean {
  * The GeoArrow spec allows for either separated or interleaved coords, but at
  * this time deck.gl only supports interleaved.
  */
-function convertStructToFixedSizeList(
+export function convertStructToFixedSizeList(
   coords:
     | ga.data.PointData
     | arrow.Data<arrow.FixedSizeList<arrow.Float64>>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -59,17 +59,15 @@ function isDataSeparatedCoords(
 /**
  * Check if the coordinates in a geometry are interleaved
  * Returns true if the coordinates are interleaved, false if separated.
- * 
+ *
  * The geometry can be point, line, polygon, etc.
  * The function recursively checks for the underlying
  * coordinate data type when it's of type List.
- * 
+ *
  * If the coordinate type is neither a FixedSizeList nor a Struct,
  * throw an error.
  */
-export function isGeomInterleaved(
-  data: arrow.Data,
-): boolean {
+export function isGeomInterleaved(data: arrow.Data): boolean {
   if (arrow.DataType.isList(data.type)) {
     return isGeomInterleaved(data.children[0]);
   } else if (arrow.DataType.isFixedSizeList(data.type)) {
@@ -84,17 +82,15 @@ export function isGeomInterleaved(
 /**
  * Check if the coordinates in a geometry are separate
  * Returns true if the coordinates are separate, false if they are interleaved.
- * 
+ *
  * The geometry can be point, line, polygon, etc.
  * The function recursively checks for the underlying
  * coordinate data type when it's of type List.
- * 
+ *
  * If the coordinate type is neither a FixedSizeList nor a Struct,
  * throw an error.
  */
-export function isGeomSeparate(
-  data: arrow.Data,
-): boolean {
+export function isGeomSeparate(data: arrow.Data): boolean {
   if (arrow.DataType.isList(data.type)) {
     return isGeomSeparate(data.children[0]);
   } else if (arrow.DataType.isStruct(data.type)) {
@@ -123,7 +119,7 @@ function convertStructToFixedSizeList(
   } else if (isDataSeparatedCoords(coords)) {
     const nDim = coords.children.length;
     const interleavedCoords = new Float64Array(coords.length * nDim);
-    
+
     for (let i = 0; i < coords.length; i++) {
       for (let j = 0; j < nDim; j++) {
         interleavedCoords[i * nDim + j] = coords.children[j].values[i];
@@ -142,7 +138,7 @@ function convertStructToFixedSizeList(
       data: interleavedCoords,
     });
 
-    const data  = arrow.makeData({
+    const data = arrow.makeData({
       type: dataType,
       length: coords.length,
       nullCount: coords.nullCount,
@@ -156,7 +152,6 @@ function convertStructToFixedSizeList(
   throw new Error(`Unsupported coordinate data type: ${coords.type}`);
 }
 
-
 /**
  * Get LineString Data with interleaved coordinates
  * from the given LineString Data with separated (struct) coordinates.
@@ -169,13 +164,13 @@ export function getInterleavedLineString(
   const interleavedPoints = convertStructToFixedSizeList(points);
 
   return arrow.makeData({
-    type: new arrow.List(new arrow.Field('element', interleavedPoints.type)),
+    type: new arrow.List(new arrow.Field("element", interleavedPoints.type)),
     length: lineStringData.length,
     nullCount: lineStringData.nullCount,
     nullBitmap: lineStringData.nullBitmap,
     valueOffsets: lineStringData.valueOffsets,
     offset: lineStringData.offset,
-    child: interleavedPoints
+    child: interleavedPoints,
   });
 }
 
@@ -190,13 +185,15 @@ export function getInterleavedPolygon(
   const interleavedLineString = getInterleavedLineString(lineString);
 
   return arrow.makeData({
-    type: new arrow.List(new arrow.Field('element', interleavedLineString.type)),
+    type: new arrow.List(
+      new arrow.Field("element", interleavedLineString.type),
+    ),
     length: polygonData.length,
     nullCount: polygonData.nullCount,
     nullBitmap: polygonData.nullBitmap,
     valueOffsets: polygonData.valueOffsets,
     offset: polygonData.offset,
-    child: interleavedLineString
+    child: interleavedLineString,
   });
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -96,10 +96,10 @@ export function isGeomSeparate(
   data: arrow.Data,
 ): boolean {
   if (arrow.DataType.isList(data.type)) {
-    return isGeomInterleaved(data.children[0]);
-  } else if (arrow.DataType.isFixedSizeList(data.type)) {
-    return true;
+    return isGeomSeparate(data.children[0]);
   } else if (arrow.DataType.isStruct(data.type)) {
+    return true;
+  } else if (arrow.DataType.isFixedSizeList(data.type)) {
     return false;
   }
 


### PR DESCRIPTION
Addresses the issue discussed in https://github.com/geoarrow/deck.gl-layers/issues/137. (Closes #137)

Overview of the proposed changes:

1. Helper functions in utils to create linestring or polygon data with interleaved (FixedSizeList) coordinates from linestring or polygon data with separated (Struct) coordinates.
2. Wherever we work with the polygon data in solid-polygon-layer, we create interleaved polygon data if the underlying coordinates are arranged in a Struct.


Thoughts:

1. I was first considering changing the getPointChild function under child.ts in geoarrow repo to create interleaved data on the fly but the earcutSinglePolygon call from earcut.ts gets quite expensive because it first gets all the coordinates of all the polygons in the polygon data and then subarrays for the single polygon at the given index of interest.
2. Thus, I decided to _transform_ the polygon data at the layer level and let earcut continue to work the way it does.


To do:

1. If this approach makes sense, I can look to other layers as well.
2. Perform additional checks in utils under isDataInterleavedCoords and isDataSeparatedCoords data (as mentioned by Kyle) such as:
   * 2, 3 or 4d data
   * names of the fields in a struct array
   * data type of the coordinates (float)
3. Extend PointData type to consider higher dimensions under type.ts in geoarrow repo.